### PR TITLE
[FIX] Workaround terraform provider bug with 1.24 K8s

### DIFF
--- a/DevOps/README.md
+++ b/DevOps/README.md
@@ -13,6 +13,7 @@ Usually it's more comfortable to use Terraform modules than just "long" manifest
 # Task
 * Install `state-metrics` with given terraform manifests (you may need to update `config_path` in the `_provider.tf` file)
   ```
+  terraform init
   terraform apply
   ```
 * Modify code to make `state-metrics` to be presented as module.


### PR DESCRIPTION
Service account can not be created for 1.24 cluster. Bug details and discussion could be foud [in this thread](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724)